### PR TITLE
Split test and dev environments in docker-compose.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,42 @@
+version: "3"
+
+services:
+  mongodb:
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=opendatafit
+      - MONGO_INITDB_ROOT_PASSWORD=password
+
+  rabbitmq:
+    ports:
+      # AMQP port
+      - "5672:5672"
+      # Management UI port
+      - "15672:15672"
+
+  store:
+    ports:
+      - "5000:5000"
+    env_file:
+      - store.dev.env
+
+  users:
+    ports:
+      - "5001:5000"
+    env_file:
+      - users.dev.env
+
+  jobjockey:
+    ports:
+      - "5002:5000"
+    env_file:
+      - jobjockey.dev.env
+
+  scheduler:
+    env_file:
+      - scheduler.dev.env
+
+  execution:
+    env_file:
+      - execution.dev.env

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,42 @@
+version: "3"
+
+services:
+  mongodb:
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=opendatafit
+      - MONGO_INITDB_ROOT_PASSWORD=password
+
+  rabbitmq:
+    ports:
+      # AMQP port
+      - "5672:5672"
+      # Management UI port
+      - "15672:15672"
+
+  store:
+    ports:
+      - "5000:5000"
+    env_file:
+      - store.test.env
+
+  users:
+    ports:
+      - "5001:5000"
+    env_file:
+      - users.test.env
+
+  jobjockey:
+    ports:
+      - "5002:5000"
+    env_file:
+      - jobjockey.test.env
+
+  scheduler:
+    env_file:
+      - scheduler.test.env
+
+  execution:
+    env_file:
+      - execution.test.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,35 +5,18 @@ services:
     image: mongo:4.4.5-bionic
     volumes:
       - ./db-data:/data/db
-    ports:
-      - "27017:27017"
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=opendatafit
-      - MONGO_INITDB_ROOT_PASSWORD=password
     networks:
       - mongodb-network
 
   rabbitmq:
     image: "rabbitmq:3-management-alpine"
-    ports:
-      # AMQP port
-      - "5672:5672"
-      # Management UI port
-      - "15672:15672"
     networks:
       - rabbitmq-network
 
   store:
     image: opendatafit/store
-    ports:
-      - "5000:5000"
     build:
       context: ${ODF_STORE_SRC}
-    environment:
-      - FLASK_SECRET_KEY=icanhaxsecretkey?
-      - JWT_SECRET_KEY=icanhaxsecretkey?
-      - MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
-      - CORS_ALLOWED_ORIGINS=*
     networks:
       - store-network
       - mongodb-network
@@ -42,16 +25,8 @@ services:
 
   users:
     image: opendatafit/users
-    ports:
-      - "5001:5000"
     build:
       context: ${ODF_USERS_SRC}
-    environment:
-      - FLASK_SECRET_KEY=icanhaxsecretkey?
-      - JWT_SECRET_KEY=icanhaxsecretkey?
-      - JWT_REFRESH_SECRET_KEY=icanhaxsecretkey??
-      - MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
-      - CORS_ALLOWED_ORIGINS=*
     networks:
       - mongodb-network
     depends_on:
@@ -59,13 +34,8 @@ services:
 
   jobjockey:
     image: opendatafit/jobjockey
-    ports:
-      - "5002:5000"
     build:
       context: ${ODF_JOBJOCKEY_SRC}
-    environment:
-      - AMQP_HOST=http://rabbitmq:5672/
-      - CORS_ALLOWED_ORIGINS=*
     networks:
       - jobjockey-network  # Used by notify test-client
       - rabbitmq-network
@@ -76,9 +46,6 @@ services:
     image: opendatafit/scheduler
     build:
       context: ${ODF_SCHEDULER_SRC}
-    environment:
-      - AMQP_HOST=http://rabbitmq:5672/
-      - LAMBDA_HOST=http://execution:8080/2015-03-31/functions/function/invocations
     networks:
       - rabbitmq-network
       - execution-network
@@ -91,10 +58,6 @@ services:
     build:
       target: development
       context: ${ODF_EXECUTION_BASE_SRC}
-    environment:
-      - OPENDATAFIT_STORE_HOST=http://store:5000/api/v1
-      # Use local Lambda RIE emulator
-      - LOCAL_LAMBDA=1
     networks:
       - execution-network
       - store-network

--- a/execution.dev.env
+++ b/execution.dev.env
@@ -1,0 +1,4 @@
+APP_ENV=development
+OPENDATAFIT_STORE_HOST=http://store:5000/api/v1
+# Use local Lambda RIE emulator
+LOCAL_LAMBDA=1

--- a/execution.test.env
+++ b/execution.test.env
@@ -1,0 +1,4 @@
+APP_ENV=testing
+OPENDATAFIT_STORE_HOST=http://store:5000/api/v1
+# Use local Lambda RIE emulator
+LOCAL_LAMBDA=1

--- a/init_db/create_user.py
+++ b/init_db/create_user.py
@@ -9,39 +9,29 @@ import pymongo
 
 from pathlib import Path
 
-# Import create_user test helper from users repo
+# Import create_or_return_user test helper from users repo
 sys.path.append(os.environ.get("ODF_USERS_SRC") + "/tests")
-from helpers import create_user  # noqa: E402
-
-# Import app configs from store repo
-sys.path.append(os.environ.get("ODF_STORE_SRC"))
-from app.config import DevelopmentConfig, TestingConfig, ProductionConfig
+from helpers import create_or_return_user  # noqa: E402
 
 
 _, EMAIL, PASSWORD, FIRST_NAME, LAST_NAME, MUGSHOT = sys.argv
 
 
-if os.environ.get("APP_ENV") == "production":
-    MONGO_URI = os.environ.get("MONGO_URI")
-    MONGO_DBNAME = ProductionConfig.MONGO_DBNAME
-    USERS_DBNAME = ProductionConfig.USERS_DBNAME
-    USERS_COLNAME = ProductionConfig.USERS_COLNAME
-else:
-    MONGO_URI = TestingConfig.MONGO_URI
-    MONGO_DBNAME = DevelopmentConfig.MONGO_DBNAME
-    USERS_DBNAME = TestingConfig.USERS_DBNAME
-    USERS_COLNAME = TestingConfig.USERS_COLNAME
-
+# These environment variables are set from dev-utils run scripts currently
+# This is a temp hack, will be set by direnv in future
+# Currently in production (maintenance box) we will have to set them manually
+MONGO_URI = os.environ.get("MONGO_URI") # Externally accessible Mongo DB URI
+USERS_DBNAME = os.environ.get("USERS_DBNAME")
+USERS_COLNAME = os.environ.get("USERS_COLNAME")
 
 # Connect to DB
 client = pymongo.MongoClient(MONGO_URI)
-db = client[MONGO_DBNAME]
 
 if MUGSHOT:
     mugshot = Path(MUGSHOT).read_text()
 
 # Create user
-create_user(
+create_or_return_user(
     collection=client[USERS_DBNAME][USERS_COLNAME],
     email=EMAIL,
     password=PASSWORD,

--- a/init_db/init_db.py
+++ b/init_db/init_db.py
@@ -8,26 +8,20 @@ import pymongo
 import json
 from pathlib import Path
 
-# Import helpers and configs from store repo
 sys.path.append(os.environ.get("ODF_STORE_SRC"))
 from app.helpers import create_datapackage
-from app.config import DevelopmentConfig, TestingConfig, ProductionConfig
 
 sys.path.append(os.environ.get("ODF_USERS_SRC") + "/tests")
-from helpers import create_user  # noqa: E402
+from helpers import create_or_return_user  # noqa: E402
 
 
-if os.environ.get("APP_ENV") == "production":
-    MONGO_URI = os.environ.get("MONGO_URI")
-    MONGO_DBNAME = ProductionConfig.MONGO_DBNAME
-    USERS_DBNAME = ProductionConfig.USERS_DBNAME
-    USERS_COLNAME = ProductionConfig.USERS_COLNAME
-else:
-    MONGO_URI = TestingConfig.MONGO_URI
-    MONGO_DBNAME = DevelopmentConfig.MONGO_DBNAME
-    USERS_DBNAME = TestingConfig.USERS_DBNAME
-    USERS_COLNAME = TestingConfig.USERS_COLNAME
-
+# These environment variables are set from dev-utils run scripts currently
+# This is a temp hack, will be set by direnv in future
+# Currently in production (maintenance box) we will have to set them manually
+MONGO_URI = os.environ.get("MONGO_URI") # Externally accessible Mongo DB URI
+MONGO_DBNAME = os.environ.get("MONGO_DBNAME")
+USERS_DBNAME = os.environ.get("USERS_DBNAME")
+USERS_COLNAME = os.environ.get("USERS_COLNAME")
 
 # Connect to DB
 client = pymongo.MongoClient(MONGO_URI)
@@ -35,8 +29,8 @@ db = client[MONGO_DBNAME]
 
 mugshot = Path("./mugshots/opendatafit.base64").read_text()
 
-# Create opendata.fit user
-opendatafit = create_user(
+# Create master opendata.fit user
+opendatafit = create_or_return_user(
     collection=client[USERS_DBNAME][USERS_COLNAME],
     email="opendatafit@proton.me",
     password="password",

--- a/init_db/load_env.dev.sh
+++ b/init_db/load_env.dev.sh
@@ -1,0 +1,6 @@
+# Usage: source load_env.dev.sh
+
+source $ODF_DEV_UTILS_SRC/load_env.sh store.dev.env
+
+# Override MONGO_URI for external access
+export MONGO_URI="mongodb://opendatafit:password@localhost:27017/"

--- a/init_db/load_env.test.sh
+++ b/init_db/load_env.test.sh
@@ -1,0 +1,6 @@
+# Usage: source load_env.test.sh
+
+source $ODF_DEV_UTILS_SRC/load_env.sh store.test.env
+
+# Override MONGO_URI for external access
+export MONGO_URI="mongodb://opendatafit:password@localhost:27017/"

--- a/init_db/set_env_dev.sh
+++ b/init_db/set_env_dev.sh
@@ -1,0 +1,8 @@
+# Usage: source set_env_test.sh
+# Temporarily set development env vars
+# Will be set by direnv in future
+# Ideally we want these in a central location, not repeated inside compose.yml
+export MONGO_URI="mongodb://opendatafit:password@localhost:27017/"
+export MONGO_DBNAME="opendatafit-store"
+export USERS_DBNAME="opendatafit-users"
+export USERS_COLNAME="users"

--- a/init_db/set_env_test.sh
+++ b/init_db/set_env_test.sh
@@ -1,0 +1,8 @@
+# Usage: source set_env_test.sh
+# Temporarily set development env vars
+# Will be set by direnv in future
+# Ideally we want these in a central location, not repeated inside compose.yml
+export MONGO_URI="mongodb://opendatafit:password@localhost:27017/"
+export MONGO_DBNAME="opendatafit-store-test"
+export USERS_DBNAME="opendatafit-users-test"
+export USERS_COLNAME="users"

--- a/jobjockey.dev.env
+++ b/jobjockey.dev.env
@@ -1,0 +1,3 @@
+APP_ENV=development
+AMQP_HOST=http://rabbitmq:5672/
+CORS_ALLOWED_ORIGINS=*

--- a/jobjockey.test.env
+++ b/jobjockey.test.env
@@ -1,0 +1,3 @@
+APP_ENV=testing
+AMQP_HOST=http://rabbitmq:5672/
+CORS_ALLOWED_ORIGINS=*

--- a/load_env.sh
+++ b/load_env.sh
@@ -1,0 +1,2 @@
+# Usage: source load_env.sh store.test.env
+export $(cat $ODF_DEV_UTILS_SRC/$@ | xargs)

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,1 @@
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,1 @@
+docker compose -f docker-compose.yml -f docker-compose.test.yml up

--- a/scheduler.dev.env
+++ b/scheduler.dev.env
@@ -1,0 +1,3 @@
+APP_ENV=development
+AMQP_HOST=http://rabbitmq:5672/
+LAMBDA_HOST=http://execution:8080/2015-03-31/functions/function/invocations

--- a/scheduler.test.env
+++ b/scheduler.test.env
@@ -1,0 +1,3 @@
+APP_ENV=testing
+AMQP_HOST=http://rabbitmq:5672/
+LAMBDA_HOST=http://execution:8080/2015-03-31/functions/function/invocations

--- a/store.dev.env
+++ b/store.dev.env
@@ -1,0 +1,8 @@
+APP_ENV=development
+FLASK_SECRET_KEY=icanhaxsecretkey?
+JWT_SECRET_KEY=icanhaxsecretkey?
+CORS_ALLOWED_ORIGINS=*
+MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
+MONGO_DBNAME=opendatafit-store
+USERS_DBNAME=opendatafit-users
+USERS_COLNAME=users

--- a/store.test.env
+++ b/store.test.env
@@ -1,0 +1,10 @@
+APP_ENV=testing
+FLASK_SECRET_KEY=icanhaxsecretkey?
+JWT_SECRET_KEY=icanhaxsecretkey?
+CORS_ALLOWED_ORIGINS=*
+MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
+MONGO_DBNAME=opendatafit-store-test
+USERS_DBNAME=opendatafit-users-test
+USERS_COLNAME=users
+# Only used in external testing environment
+AUTH_ENDPOINT=http://localhost:5001/api/v1/oauth/token

--- a/users.dev.env
+++ b/users.dev.env
@@ -1,0 +1,7 @@
+APP_ENV=development
+FLASK_SECRET_KEY=icanhaxsecretkey?
+JWT_SECRET_KEY=icanhaxsecretkey?
+JWT_REFRESH_SECRET_KEY=icanhaxsecretkey??
+MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
+CORS_ALLOWED_ORIGINS=*
+MONGO_DBNAME=opendatafit-users

--- a/users.test.env
+++ b/users.test.env
@@ -1,0 +1,7 @@
+APP_ENV=testing
+FLASK_SECRET_KEY=icanhaxsecretkey?
+JWT_SECRET_KEY=icanhaxsecretkey?
+JWT_REFRESH_SECRET_KEY=icanhaxsecretkey??
+MONGO_URI=mongodb://opendatafit:password@mongodb:27017/
+CORS_ALLOWED_ORIGINS=*
+MONGO_DBNAME=opendatafit-users-test


### PR DESCRIPTION
Fixes https://github.com/opendatafit/dev-utils/issues/14

Also updates init_db scripts to use local environment variables pulled from .envs to avoid duplication.